### PR TITLE
feat: Integrate custom CKEditor 5 build structure and update toolbar

### DIFF
--- a/frontend/src/ckeditor5-custom-build/ckeditor.js
+++ b/frontend/src/ckeditor5-custom-build/ckeditor.js
@@ -1,0 +1,65 @@
+// frontend/src/ckeditor5-custom-build/ckeditor.js
+// Este arquivo simula um build customizado do CKEditor 5.
+// Em um cenário real, este arquivo seria gerado pelo processo de build do CKEditor
+// e conteria o editor compilado com todos os plugins customizados.
+
+// Para esta simulação, vamos reexportar o ClassicEditor do build-classic.
+// Plugins como Alignment, TableProperties, TableCellProperties, SourceEditing já estão
+// inclusos no @ckeditor/ckeditor5-build-classic. A diferença em um build customizado
+// real seria a possibilidade de adicionar plugins de terceiros ou remover plugins não utilizados
+// para otimizar o tamanho do build.
+
+import ClassicEditorBase from '@ckeditor/ckeditor5-build-classic';
+
+// Se você estivesse construindo a partir do zero, você importaria os plugins aqui:
+// import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+// import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+// import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+// import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+// import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
+// import Table from '@ckeditor/ckeditor5-table/src/table';
+// import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
+// import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
+// import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+// import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+// ... outros plugins ...
+
+export default class ClassicEditor extends ClassicEditorBase {
+    // Em um build customizado real, você poderia adicionar ou sobrescrever a configuração padrão aqui,
+    // ou listar os builtinPlugins se não estivesse estendendo um build existente.
+    // static builtinPlugins = [
+    //     Essentials, Paragraph, Bold, Italic, Alignment, Table, TableToolbar,
+    //     TableProperties, TableCellProperties, SourceEditing,
+    //     // ... outros plugins
+    // ];
+
+    // A configuração da toolbar é geralmente passada na instanciação do editor,
+    // mas também pode ser definida por padrão aqui em um build customizado.
+    // static defaultConfig = {
+    //     toolbar: {
+    //         items: [
+    //             'heading', '|',
+    //             'bold', 'italic', '|',
+    //             'alignment', '|', // O plugin Alignment adiciona 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify'
+    //             'insertTable', '|',
+    //             'sourceEditing', '|',
+    //             'undo', 'redo'
+    //         ]
+    //     },
+    //     table: {
+    //         contentToolbar: [
+    //             'tableColumn', 'tableRow', 'mergeTableCells',
+    //             'tableProperties', 'tableCellProperties'
+    //         ]
+    //     },
+    //     language: 'pt-br'
+    // };
+}
+
+// Nota: A tentativa de modificar `ClassicEditor.builtinPlugins` diretamente em um build pré-compilado
+// como o `@ckeditor/ckeditor5-build-classic` não é a forma correta de adicionar plugins.
+// Plugins precisam ser parte do processo de compilação do editor.
+// Este arquivo simula o resultado de tal processo.
+// A configuração da toolbar nos componentes React é o que efetivamente determinará
+// quais botões (e, por consequência, quais plugins) estarão ativos, assumindo que
+// os plugins estão presentes no build.

--- a/frontend/src/ckeditor5-custom-build/package.json
+++ b/frontend/src/ckeditor5-custom-build/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ckeditor5-custom-build",
+  "version": "1.0.0",
+  "description": "Simulated custom build of CKEditor 5 for CRM project.",
+  "main": "ckeditor.js",
+  "license": "ISC"
+}

--- a/frontend/src/components/PropostaWizard/GerarContratoModal.js
+++ b/frontend/src/components/PropostaWizard/GerarContratoModal.js
@@ -2,35 +2,35 @@
 import React, { useState, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+// Importar o editor do build customizado simulado
+import ClassicEditor from './../../ckeditor5-custom-build/ckeditor';
 
 import { getModelosContrato } from '../../api/modeloContratoApi';
 import { gerarDocumentoApi, updatePropostaContratoApi } from '../../api/propostaContratoApi';
 import './GerarContratoModal.css';
 
-// Configuração do editor CKEditor
+// Configuração do editor CKEditor atualizada
 const editorConfiguration = {
     toolbar: [
         'heading', '|',
         'bold', 'italic', '|',
         'alignment:left', 'alignment:center', 'alignment:right', 'alignment:justify', '|',
-        'insertTable', '|', // Removido 'tableColumn', 'tableRow', 'mergeTableCells' da toolbar principal conforme solicitado implicitamente
-        // 'link', '|', // Removido
-        // 'bulletedList', 'numberedList', '|', // Removido
-        // 'fontColor', 'fontBackgroundColor', '|', // Removido
-        // 'sourceEditing', '|', // Removido da toolbar principal, pode ser adicionado se necessário em outro local ou mantido se a remoção não foi intencional
+        'insertTable', 'tableColumn', 'tableRow', 'mergeTableCells', '|',
+        'tableProperties', 'tableCellProperties', '|',
+        'sourceEditing', '|',
+        'link', 'bulletedList', 'numberedList', 'fontColor', 'fontBackgroundColor', '|',
         'undo', 'redo'
     ],
     language: 'pt-br',
     table: {
-        contentToolbar: [
+        contentToolbar: [ // Mantendo a toolbar de tabela rica em funcionalidades
             'tableColumn', 'tableRow', 'mergeTableCells', '|',
             'tableProperties', 'tableCellProperties', '|',
             'alignment:left', 'alignment:center', 'alignment:right', 'alignment:justify'
         ]
     },
-    // Alignment plugin é carregado por padrão no ClassicBuild quando os botões são especificados na toolbar.
-    // TableProperties e TableCellProperties também.
+    // Os plugins (Alignment, TableProperties, TableCellProperties, SourceEditing, etc.)
+    // são esperados estarem inclusos e ativos no 'ClassicEditor' importado do build customizado.
 };
 
 

--- a/frontend/src/pages/Admin/ModeloContrato/ModeloContratoFormPage/ModeloContratoFormPage.js
+++ b/frontend/src/pages/Admin/ModeloContrato/ModeloContratoFormPage/ModeloContratoFormPage.js
@@ -6,7 +6,8 @@ import { createModeloContrato, getModeloContratoById, updateModeloContrato } fro
 import './ModeloContratoFormPage.css';
 
 import { CKEditor } from '@ckeditor/ckeditor5-react';
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+// Importar o editor do build customizado simulado
+import ClassicEditor from './../../../../ckeditor5-custom-build/ckeditor';
 
 const TIPO_DOCUMENTO_OPCOES = ["Proposta", "Contrato de Reserva", "Contrato de Compra e Venda", "Outro"];
 
@@ -94,30 +95,28 @@ const LISTA_PLACEHOLDERS_DISPONIVEIS = [
   }
 ];
 
-// Configuração do editor CKEditor
+// Configuração do editor CKEditor atualizada
 const editorConfiguration = {
     toolbar: [
         'heading', '|',
         'bold', 'italic', '|',
         'alignment:left', 'alignment:center', 'alignment:right', 'alignment:justify', '|',
-        'insertTable', '|',
-        // Itens removidos da toolbar principal para seguir a especificação da tarefa:
-        // 'link', 'bulletedList', 'numberedList', 'fontColor', 'fontBackgroundColor',
-        // 'sourceEditing' (este último pode ser importante manter, confirmar se a remoção foi intencional)
-        // 'tableColumn', 'tableRow', 'mergeTableCells' (movidos para table.contentToolbar)
+        'insertTable', 'tableColumn', 'tableRow', 'mergeTableCells', '|',
+        'tableProperties', 'tableCellProperties', '|',
+        'sourceEditing', '|',
+        'link', 'bulletedList', 'numberedList', 'fontColor', 'fontBackgroundColor', '|',
         'undo', 'redo'
     ],
     language: 'pt-br',
     table: {
-        contentToolbar: [
+        contentToolbar: [ // Mantendo a toolbar de tabela rica em funcionalidades
             'tableColumn', 'tableRow', 'mergeTableCells', '|',
             'tableProperties', 'tableCellProperties', '|',
             'alignment:left', 'alignment:center', 'alignment:right', 'alignment:justify'
         ]
     },
-    // Os plugins Alignment, TableProperties e TableCellProperties são ativados
-    // automaticamente pelo ClassicEditor quando seus respectivos botões são
-    // adicionados às configurações de toolbar.
+    // Os plugins (Alignment, TableProperties, TableCellProperties, SourceEditing, etc.)
+    // são esperados estarem inclusos e ativos no 'ClassicEditor' importado do build customizado.
 };
 
 function ModeloContratoFormPage() {


### PR DESCRIPTION
- Simulates a custom CKEditor 5 build by creating a local 'ckeditor5-custom-build' directory.
- Updates components (GerarContratoModal, ModeloContratoFormPage) to import the editor from this simulated custom build path.
- Standardizes and expands the main toolbar configuration in both components to include alignment, full table controls, source editing, link, list, and font options.
- Retains a rich context-specific table toolbar.

Note: The actual editor functionality still relies on the plugins available in '@ckeditor/ckeditor5-build-classic' due to the nature of the build simulation. A real custom build process is needed for full plugin customization and optimization.